### PR TITLE
feature/taskvine_worker_cmds

### DIFF
--- a/merlin/main.py
+++ b/merlin/main.py
@@ -340,6 +340,22 @@ def query_workers(args):
     router.query_workers(args.task_server, worker_names, args.queues, args.workers)
 
 
+def query_study(args):
+    """
+    CLI command for querying information about studies.
+    NOTE would be cool if this showed metadata about the study too
+    NOTE need to add in metadata that Maestro saves so maybe we can pull something from that?
+    NOTE would this be better if we pass in a currently running study (output workspace) rather than a spec file?
+
+    :param args: parsed CLI arguments
+    """
+    print(banner_small)
+
+    spec_path = verify_filepath(args.specification)
+    spec = MerlinSpec.load_specification(spec_path)
+    router.query_study(spec)
+
+
 def stop_workers(args):
     """
     CLI command for stopping all workers.
@@ -1072,6 +1088,14 @@ def generate_diagnostic_parsers(subparsers: ArgumentParser) -> None:
         help="Ignore any prompts provided. This will default to the latest study \
             if you provide a spec file rather than a study workspace.",
     )
+
+    # merlin query-study
+    query_merlin_study: ArgumentParser = subparsers.add_parser(
+        "query-study",
+        help="List information about the study.",
+    )
+    query_merlin_study.set_defaults(func=query_study)
+    query_merlin_study.add_argument("specification", type=str, help="Path to a Merlin YAML spec file")
 
     # merlin queue-info
     queue_info: ArgumentParser = subparsers.add_parser(

--- a/merlin/spec/all_keys.py
+++ b/merlin/spec/all_keys.py
@@ -76,10 +76,12 @@ STUDY_STEP_RUN = {
 
 PARAMETER = {"values", "label"}
 
-MERLIN_RESOURCES = {"task_server", "overlap", "workers"}
+MERLIN_RESOURCES = {"task_server", "overlap", "workers", "managers"}
 
 MERLIN = {"resources", "samples"}
 
-WORKER = {"steps", "nodes", "batch", "args", "machines"}
+CELERY_WORKER = {"steps", "nodes", "batch", "args", "machines"}
+
+TASKVINE_WORKER = {"args", "cores", "disk", "manager", "memory", "nodes"}
 
 SAMPLES = {"generate", "level_max_dirs", "file", "column_labels"}

--- a/merlin/spec/defaults.py
+++ b/merlin/spec/defaults.py
@@ -46,7 +46,11 @@ MERLIN = {
     }
 }
 
-WORKER = {"steps": ["all"], "nodes": None, "batch": None}
+CELERY_WORKER = {"steps": ["all"], "nodes": None, "batch": None}
+
+TASKVINE_MANAGER = {"default_manager": None}
+
+TASKVINE_WORKER = {"manager": "default_manager", "nodes": 1, "cores": None, "memory": None, "disk": None}
 
 SAMPLES = {
     "generate": {"cmd": "echo 'Insert sample-generating command here'"},

--- a/merlin/spec/merlinspec.json
+++ b/merlin/spec/merlinspec.json
@@ -210,15 +210,20 @@
         "properties": {
           "task_server": {"type": "string", "minLength": 1},
           "overlap": {"type": "boolean"},
-          "mangers": {
+          "managers": {
             "type": "object",
             "patternProperties": {
-              "^.+": {
-                "type": "object"
+              "^.+$": {
+                "oneOf": [
+                  {"type": "null"},
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                ]
               }
-            
             }
-	  },
+          },
           "workers": {
             "type": "object",
             "patternProperties": {
@@ -257,6 +262,7 @@
                   },
                   "manager": {
                     "anyOf": [
+                      {"type": "string", "minLength": 1},
                       {"type": "string", "pattern": "^\\$\\(\\w+\\)$"}
                     ]
                   },

--- a/merlin/study/vineadapter.py
+++ b/merlin/study/vineadapter.py
@@ -46,13 +46,12 @@ from tabulate import tabulate
 
 from merlin.common.dumper import dump_handler
 from merlin.config import Config
+from merlin.spec.specification import MerlinSpec
 from merlin.study.batch import batch_check_parallel, batch_worker_launch
 from merlin.utils import apply_list_of_regex, check_machines, get_procs, get_yaml_var, is_running
 
 
 LOG = logging.getLogger(__name__)
-
-# TODO figure out a better way to handle the import of celery app and CONFIG
 
 
 def run_taskvine(study, run_mode=None):
@@ -78,8 +77,48 @@ def run_taskvine(study, run_mode=None):
     # Send the tasks to the server
     queue_merlin_study(study, adapter_config)
 
+def start_taskvine_workers(
+    spec: MerlinSpec,
+    steps: List[str],
+    worker_args: str,
+    disable_logs: bool,
+    just_return_command: bool
+):
+    """
+    Start the TaskVine workers on the allocation.
 
-# get r
+    :param spec: A MerlinSpec object representing our study
+    :param steps: A list of steps to start workers for
+    :param worker_args: A string of arguments to provide to the workers
+    :param disable_logs: A boolean flag to turn off the logs for the workers
+    :param just_return_command: When True, workers/managers aren't started and just the launch
+                                commands for them are returned
+    """
+    # TODO Start up the workers
+    print(spec.merlin["resources"]["workers"])
+
+
+def purge_taskvine_tasks(spec: MerlinSpec, force: bool):
+    """
+    Purge tasks for the specified spec file.
+
+    :param spec: A MerlinSpec object representing our study
+    :param force: If True, purge without asking for confirmation
+    """
+    # TODO implement purge functionality
+    print(spec.merlin["resources"]["managers"])
+
+
+def query_taskvine_study(spec: MerlinSpec):
+    """
+    Query the managers with vine-status.
+
+    :param spec: A MerlinSpec object representing our study
+    """
+    # TODO implement query functionality
+    print(spec.merlin["resources"]["managers"])
+
+
 def get_running_managers(celery_app_name: str, test_mode: bool = False) -> List[str]:
     """
     Check for running celery workers by looking at the currently running processes.


### PR DESCRIPTION
Added the ability to read in manager/worker settings for taskvine. This will also populate defaults in case nothing was given by the user.

Additionally, this branch sets up templates for the taskvine adapter to start workers, purge tasks, and query the managers for information on the study.